### PR TITLE
Allow multi reactions

### DIFF
--- a/reactbot/bot.py
+++ b/reactbot/bot.py
@@ -106,4 +106,4 @@ class ReactBot(Plugin):
                     await rule.execute(evt, match)
                 except Exception:
                     self.log.exception(f"Failed to execute {name} in {evt.room_id}")
-                return
+

--- a/reactbot/bot.py
+++ b/reactbot/bot.py
@@ -106,4 +106,5 @@ class ReactBot(Plugin):
                     await rule.execute(evt, match)
                 except Exception:
                     self.log.exception(f"Failed to execute {name} in {evt.room_id}")
-
+                if not rule.continue_after_match:
+                    return

--- a/reactbot/config.py
+++ b/reactbot/config.py
@@ -64,6 +64,7 @@ class Config(BaseProxyConfig):
                 type=EventType.find(rule["type"]) if "type" in rule else None,
                 template=self.templates[rule["template"]],
                 variables=self._parse_variables(rule),
+                continue_after_match=rule.get("continue_after_match", True),
             )
         except Exception as e:
             raise ConfigError(f"Failed to load {name}") from e

--- a/reactbot/rule.py
+++ b/reactbot/rule.py
@@ -35,6 +35,7 @@ class Rule:
     template: Template
     type: Optional[EventType]
     variables: Dict[str, Any]
+    continue_after_match: bool
 
     def _check_not_match(self, body: str) -> bool:
         for pattern in self.not_matches:

--- a/samples/your-opinion.yaml
+++ b/samples/your-opinion.yaml
@@ -1,0 +1,44 @@
+templates:
+    reaction:
+        type: m.reaction
+        variables:
+            react_to_event: '{{event.content.get_reply_to() or event.event_id}}'
+        content:
+            m.relates_to:
+                rel_type: m.annotation
+                event_id: $${react_to_event}
+                key: $${reaction}
+
+
+default_flags:
+- ignorecase
+antispam:
+    room:
+        max: 60
+        delay: 60
+    user:
+        max: 60
+        delay: 60
+
+rules:
+    opinon_up:
+        raw: false
+        matches: '#youropinion\b(?!`)'
+        template: reaction
+        continue_after_match: true
+        variables:
+            reaction: 👍
+    opinion_down:
+        raw: false
+        matches: '#youropinion\b(?!`)'
+        template: reaction
+        continue_after_match: true
+        variables:
+            reaction: 👎
+    opinon_shrug:
+        raw: false
+        matches: '#youropinion\b(?!`)'
+        template: reaction
+        variables:
+            reaction: 🤷
+


### PR DESCRIPTION
This allows multiple rules to match in sequence.

It thereby also allows for multiple reactions on the same event.

## Motivation

We often use reactions as a simple voting scheme, and to make the use easier looked for a bot which can add some standard reactions.