### PR TITLE
Fix default_flags indentation

### DIFF
--- a/samples/stallman.yaml
+++ b/samples/stallman.yaml
@@ -8,7 +8,7 @@ templates:
             body: $${message}
 
 default_flags:
-- ignorecase
+    - ignorecase
 
 antispam:
     room:


### PR DESCRIPTION
Default flags' array was not indented properly. This causes the bot to ignore the ignorecase flag